### PR TITLE
chore: Increase target group health check interval

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -142,7 +142,7 @@ resource "aws_lb_target_group" "tfe" {
     healthy_threshold   = 2
     unhealthy_threshold = 10
     timeout             = 5
-    interval            = 45
+    interval            = 60
     matcher             = 200
   }
 }


### PR DESCRIPTION
After testing, it has been observed that on first startup, both TFE nodes can take longer than the original configuration to respond with 200 to the health check.