### PR TITLE
chore: Grab the ARN of the RDS master user secret from the resource directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ Infrastructure as Code Repository to Standup TFE
 | [aws_kms_key.ssm](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/kms_key) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/region) | data source |
 | [aws_route53_zone.tfe](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/route53_zone) | data source |
-| [aws_secretsmanager_secret_version.master_user_secret](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/secretsmanager_secret_version) | data source |
 | [http_http.myip](https://registry.terraform.io/providers/hashicorp/http/3.4.3/docs/data-sources/http) | data source |
 
 ## Inputs

--- a/iam.tf
+++ b/iam.tf
@@ -99,7 +99,7 @@ data "aws_iam_policy_document" "tfe_secrets_manager" {
       "secretsmanager:ListSecretVersionIds"
     ]
     resources = [
-      data.aws_secretsmanager_secret_version.master_user_secret.arn,
+      aws_db_instance.tfe.master_user_secret[0].secret_arn
     ]
   }
   statement {

--- a/main.tf
+++ b/main.tf
@@ -35,10 +35,6 @@ data "aws_ami" "debian" {
   }
 }
 
-data "aws_secretsmanager_secret_version" "master_user_secret" {
-  secret_id = aws_db_instance.tfe.master_user_secret[0].secret_arn
-}
-
 data "aws_kms_key" "rds" {
   key_id = "alias/aws/rds"
 }


### PR DESCRIPTION
Removing the `data "aws_secretsmanager_secret_version" "master_user_secret"` data source since it was being used to get the resource ARN (not the actual secret).