### PR TITLE
feat: Add a check to ensure instances are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,10 @@ Infrastructure as Code Repository to Standup TFE
 | [random_string.tfe_encryption_password](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/string) | resource |
 | [random_string.tfe_redis_password](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/string) | resource |
 | [aws_ami.debian](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/ami) | data source |
+| [aws_availability_zones.all](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/caller_identity) | data source |
+| [aws_ec2_instance_type_offering.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/ec2_instance_type_offering) | data source |
+| [aws_ec2_instance_type_offering.tfe](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/ec2_instance_type_offering) | data source |
 | [aws_iam_policy_document.ec2_modify_metadata](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_assume_role](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tfe_get_parameters](https://registry.terraform.io/providers/hashicorp/aws/5.53.0/docs/data-sources/iam_policy_document) | data source |
@@ -157,5 +160,8 @@ Infrastructure as Code Repository to Standup TFE
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_ec2_bastion_instance_type_availability"></a> [ec2\_bastion\_instance\_type\_availability](#output\_ec2\_bastion\_instance\_type\_availability) | Show the list of Availability Zones that the configured EC2 instance type is available in. |
+| <a name="output_ec2_tfe_instance_type_availability"></a> [ec2\_tfe\_instance\_type\_availability](#output\_ec2\_tfe\_instance\_type\_availability) | Show the list of Availability Zones that the configured EC2 instance type is available in. |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,40 @@ data "aws_route53_zone" "tfe" {
   name = var.route53_zone_name
 }
 
+data "aws_availability_zones" "all" {}
+
+data "aws_ec2_instance_type_offering" "bastion" {
+  for_each = toset(data.aws_availability_zones.all.names)
+
+  filter {
+    name   = "instance-type"
+    values = [var.ec2_bastion_instance_type]
+  }
+
+  filter {
+    name   = "location"
+    values = [each.value]
+  }
+
+  location_type = "availability-zone"
+}
+
+data "aws_ec2_instance_type_offering" "tfe" {
+  for_each = toset(data.aws_availability_zones.all.names)
+
+  filter {
+    name   = "instance-type"
+    values = [var.ec2_tfe_instance_type]
+  }
+
+  filter {
+    name   = "location"
+    values = [each.value]
+  }
+
+  location_type = "availability-zone"
+}
+
 data "http" "myip" {
   url = "http://ipv4.icanhazip.com"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,9 @@
+output "ec2_bastion_instance_type_availability" {
+  description = "Show the list of Availability Zones that the configured EC2 instance type is available in."
+  value       = { for az, details in data.aws_ec2_instance_type_offering.bastion : az => details.instance_type }
+}
+
+output "ec2_tfe_instance_type_availability" {
+  description = "Show the list of Availability Zones that the configured EC2 instance type is available in."
+  value       = { for az, details in data.aws_ec2_instance_type_offering.tfe : az => details.instance_type }
+}


### PR DESCRIPTION
The data source will essentially check the availability of EC2 instances in all AWS regions and fail if they're not available. This will ensure when people configure an EC2 instance type, it won't wait until the end of an apply to fail.