### PR TITLE
feat: Publish Terraform module to the private registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,14 @@ jobs:
     runs-on: ubuntu-24.04
     # Skip running release workflow on forks
     if: github.repository_owner == 'craigsloggett-lab'
+    outputs:
+      new_release_published: ${{ steps.release.outputs.new_release_published }}
+      new_release_version: ${{ steps.release.outputs.new_release_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Release
+        id: release
         uses: cycjimmy/semantic-release-action@b1b432f13acb7768e0c8efdec416d363a57546f2 # v4.1.1
         with:
           semantic_version: 23.0.5
@@ -28,3 +32,34 @@ jobs:
             conventional-changelog-conventionalcommits@7.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish-new-hcp-terraform-module-version:
+    name: Publish New Module Version
+    runs-on: ubuntu-24.04
+    if: needs.release.outputs.new_release_published == 'true'
+    needs: release
+    env:
+      TF_TOKEN_app_terraform_io: ${{ secrets.HCP_TERRAFORM_ADMIN_TEAM_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - name: Publish New HCP Terraform Module Version
+        run: |
+          version="${{ needs.release.outputs.new_release_version }}"
+          commit_sha="$(git rev-parse HEAD)"
+
+          cat <<EOF >payload.json
+          {
+            "data": {
+              "type": "registry-module-versions",
+              "attributes": {
+                "version": "${version}",
+                "commit-sha": "${commit_sha}"
+              }
+            }
+          }
+          EOF
+
+          set -- --header "Authorization: Bearer ${TF_TOKEN_app_terraform_io}" --header "Content-Type: application/vnd.api+json"
+          set -- "$@" --silent --request POST --data @payload.json
+
+          curl "$@" https://app.terraform.io/api/v2/organizations/craigsloggett-lab/registry-modules/private/craigsloggett-lab/tfe-fdo-docker-active-active/aws/versions


### PR DESCRIPTION
ci: Add a job to the release workflow to publish the latest release to the private module registry.